### PR TITLE
feat(java-devel): downgrade maven version to 3.6.3 in all java dev

### DIFF
--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -51,7 +51,7 @@ ENV MAVEN_HOME=/usr/share/maven
 
 RUN <<EOF
     curl -sSfL \
-        https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+        https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
         | tar xzf - -C /usr/share && \
     ln -s /usr/share/apache-maven-${MAVEN_VERSION} ${MAVEN_HOME} && \
     ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn

--- a/java-devel/metadata.json
+++ b/java-devel/metadata.json
@@ -3,42 +3,30 @@
   "properties": [
     {
       "version": "1.8.0",
-      "upstream": {
-        "name": "vector",
-        "version": "0.39.0"
-      },
       "dependencies": {
-        "maven": "3.9.8"
+        "vector": "0.39.0",
+        "maven": "3.6.3"
       }
     },
     {
       "version": "11",
-      "upstream": {
-        "name": "vector",
-        "version": "0.39.0"
-      },
       "dependencies": {
-        "maven": "3.9.8"
+        "vector": "0.39.0",
+        "maven": "3.6.3"
       }
     },
     {
       "version": "17",
-      "upstream": {
-        "name": "vector",
-        "version": "0.39.0"
-      },
       "dependencies": {
-        "maven": "3.9.8"
+        "vector": "0.39.0",
+        "maven": "3.6.3"
       }
     },
     {
       "version": "21",
-      "upstream": {
-        "name": "vector",
-        "version": "0.39.0"
-      },
       "dependencies": {
-        "maven": "3.9.8"
+        "vector": "0.39.0",
+        "maven": "3.6.3"
       }
     }
   ]


### PR DESCRIPTION
This pull request downgrades the Maven version to 3.6.3 in all Java development files. The Dockerfile and metadata.json files have been modified to reflect this change.