### PR TITLE
refactor(script): adaptive image builder, impl buildah, podman

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,50 @@
+name: 'Build production image'
+description: 'Build production image'
+inputs:
+  builder_name:
+    description: 'The name of the builder'
+    required: false
+    default: 'builder'
+  products:
+    description: |
+      The products to build, the name sperated by space. e.g. "name1:version1 name1:version2 name2:version1"
+      If build a product without version, just use the name. we will build all versions of the product.
+    required: true
+  push:
+    description: |
+      Push the image to registry after build.
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Build production image
+      shell: bash
+      env:
+        BUILDER_NAME: ${{ inputs.builder_name }}
+        PRODUCTS: ${{ inputs.products }}
+        PUSH: ${{ inputs.push }}
+      run: |
+        set -ex
+        
+        for product in $PRODUCTS; do
+          args=(".scripts/build.sh" "product")
+
+          if [[ $product == *":"* ]]; then
+            name=$(echo $product | cut -d':' -f1)
+            version=$(echo $product | cut -d':' -f2)
+            args+=("$name")
+            if [ -n "$version" ]; then
+              args+=("--product-version" "$version")
+            fi
+          else
+            args+=("$product")
+          fi
+
+          if [ "$PUSH" = "true" ]; then
+            args+=("--push")
+          fi
+
+          docker exec -w /app $BUILDER_NAME "${args[@]}"
+        done

--- a/.github/actions/install-buildah/action.yml
+++ b/.github/actions/install-buildah/action.yml
@@ -1,0 +1,71 @@
+name: 'Setup buildah'
+description: |
+  Due to the buildah 1.33.7 of ubuntu 24.04 do not support buildah heredoc syntax,
+  we build image in buildah container
+  Note: buildah 1.33.0 support heredoc syntax, but it is be patched in ubuntu 24.04.
+  When buildah heredoc syntax is available, we can directly build image in the runner.
+
+inputs:
+  buildah_version:
+    description: 'The version of buildah to install'
+    required: false
+    default: 'latest'
+  username:
+    description: 'The username for the registry'
+    required: false
+  password:
+    description: 'The password for the registry'
+    required: false
+  registry:
+    description: 'The registry to login to'
+    required: false
+    default: 'quay.io'
+  builder_name:
+    description: 'The name of the builder'
+    required: false
+    default: 'builder'
+outputs:
+  buildah_version:
+    description: 'The version of buildah installed'
+    value: ${{ inputs.buildah_version }}
+  builder_name:
+    description: 'The name of the builder'
+    value: ${{ inputs.builder_name }}
+
+runs:
+  using: 'composite'
+  steps:
+    # we need cross platform support
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Start buildah container
+      shell: bash
+      env:
+        BUILDER_NAME: ${{ inputs.builder_name }}
+        REGISTRY: ${{ inputs.registry }}
+        BUILDAH_VERSION: ${{ inputs.buildah_version }}
+        USERNAME: ${{ inputs.username }}
+        PASSWORD: ${{ inputs.password }}
+      run: |
+        set -ex
+        # start buildah in docker container
+        docker run \
+          --privileged \
+          --name $BUILDER_NAME \
+          -e BUILDAH_ISOLATION=chroot \
+          -e BUILDAH_STORAGE_DRIVER=vfs \
+          -e CONTAINER_TOOL_PROVIDER=buildah \
+          -e CI_SCRIPT_DEBUG=true \
+          -e REGISTRY=${REGISTRY} \
+          -v $(pwd):/app \
+          -d \
+          quay.io/buildah/stable:$BUILDAH_VERSION \
+            tail -f /dev/null
+
+        # install required tools
+        docker exec $BUILDER_NAME dnf install -y jq
+
+        # login to quay.io
+        if [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
+          docker exec $BUILDER_NAME buildah login "$REGISTRY" --username "$USERNAME" --password "$PASSWORD"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ env:
   REGISTRY: quay.io/zncdatadev
   DOCKER_CACHE_DIR: /tmp/docker-cache
   CI_SCRIPT_DEBUG: true
+  CONTAINER_TOOL_PROVIDER: buildah
 
 jobs:
   linter_code_base:
     name: Markdown Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -30,7 +31,7 @@ jobs:
   
   prepare_updated_product:
     name: Prepare Updated Product
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       BEFORE_COMMIT_SHA: ${{ steps.get_updated_product.outputs.BEFORE_COMMIT_SHA }}
       AFTER_COMMIT_SHA: ${{ steps.get_updated_product.outputs.AFTER_COMMIT_SHA }}
@@ -100,12 +101,13 @@ jobs:
         PRODUCTS=$(jq -c '.products | tostring' output.json)
         INFRA=$(jq -c '.infra | tostring' output.json)
         echo "PRODUCTS: $PRODUCTS, INFRA: $INFRA"
+        
         echo "PRODUCTS=$PRODUCTS" >> "$GITHUB_OUTPUT"
         echo "INFRA=$INFRA" >> "$GITHUB_OUTPUT"
 
   test_infra:
     name: Test Infra
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: 
       - prepare_updated_product
     steps:
@@ -133,41 +135,46 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache docker
-      id: cache-buildx
-      uses: actions/cache@v4
-      with:
-        path: 
-          /tmp/docker-cache
-        key: ${{ runner.os }}-docker-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-docker-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Install jq
       uses: dcarbone/install-jq-action@v2.1.0
     - name: Check version
       run: |
         bash --version
         jq --version
-        docker info
+        buildah version
+        podman info
     - name: Show Usage
       run: |
         free -h
         df -h
         lsblk
+    - name: Install buildah
+      id: install_buildah
+      uses: ./.github/actions/install-buildah
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build Infra
+      id: build_infra
       run: |
         set -ex
         INFRA="${{ needs.prepare_updated_product.outputs.INFRA }}"
         echo "INFRA from output: $INFRA"
         
+        products=()
         # build infra
         for item in $(echo "${INFRA}" | jq -r '.[]'); do
-            .scripts/build.sh product $item
+            # /app/.scripts/build.sh product $item
+            products+=($item)
         done
+
+        # save as space separated string to output
+        echo "PRODUCTS=${products[*]}" >> "$GITHUB_OUTPUT"
+    - name: Build Images
+      uses: ./.github/actions/build
+      with:
+        products: ${{ steps.build_infra.outputs.PRODUCTS }}
+        push: false
     - name: Show Usage
       run: |
         free -h
@@ -176,7 +183,7 @@ jobs:
 
   prepare_product_matrix:
     name: Prepare Product Matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: prepare_updated_product
     outputs:
       PRODUCT_MATRIX: ${{ steps.get_product_matrix.outputs.PRODUCT_MATRIX }}
@@ -216,7 +223,7 @@ jobs:
     
   test_product:
     name: Test Product
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: prepare_product_matrix
     if: ${{ needs.prepare_product_matrix.outputs.PRODUCT_MATRIX != '[]' }}
     strategy:
@@ -247,52 +254,29 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache docker
-      id: cache-buildx
-      uses: actions/cache@v4
-      with:
-        path: 
-          /tmp/docker-cache
-        key: ${{ runner.os }}-docker-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-docker-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Install jq
       uses: dcarbone/install-jq-action@v2.1.0
     - name: Check version
       run: |
         bash --version
         jq --version
-        docker info
+        buildah version
+        podman info
     - name: Show Usage
       run: |
         free -h
         df -h
         lsblk
+    - name: Install buildah
+      uses: ./.github/actions/install-buildah
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build Product
-      run: |
-        set -ex
-
-        . ./.scripts/lib.sh
-
-        PRODUCT="${{ matrix.product }}"
-        echo "PRODUCT from matrix: $PRODUCT"
-        
-        product_name=$(echo $PRODUCT | cut -d':' -f1)
-        product_version=$(echo $PRODUCT | cut -d':' -f2)
-
-        metadata_file="${product_name}/metadata.json"
-
-        # build product
-        for property in $(jq -c '.properties[]' $metadata_file); do
-          version=$(echo $property | jq -r '.version')
-          if [ "$version" == "$product_version" ]; then
-            .scripts/build.sh product --product-version $product_version $product_name
-          fi
-        done
+      uses: ./.github/actions/build
+      with:
+        products: ${{ matrix.product }}
+        push: false
     - name: Show Usage
       run: |
         free -h
@@ -301,7 +285,7 @@ jobs:
 
   deploy_infra:
     name: Deploy Infra
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: 
       - prepare_updated_product
       - test_infra
@@ -331,28 +315,16 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache docker
-      id: cache-buildx
-      uses: actions/cache@v4
-      with:
-        path: 
-          /tmp/docker-cache
-        key: ${{ runner.os }}-docker-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-docker-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Install jq
       uses: dcarbone/install-jq-action@v2.1.0
     - name: Check version
       run: |
         bash --version
         jq --version
-        docker info
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
+        buildah version
+        podman info
+    - name: Login to quay.io
+      uses: redhat-actions/podman-login@v1
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -362,15 +334,32 @@ jobs:
         free -h
         df -h
         lsblk
+    - name: Install buildah
+      uses: ./.github/actions/install-buildah
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: Deploy Infra
+      id: deploy_infra
       run: |
         set -ex
         INFRA="${{ needs.prepare_updated_product.outputs.INFRA }}"
         echo "INFRA from output: $INFRA"
+        
+        products=()
+
         # deploy infra
         for item in $(echo "${INFRA}" | jq -r '.[]'); do
-            .scripts/build.sh product --push --progress plain $item 
+          products+=($item)
         done
+
+        # save as space separated string to output
+        echo "PRODUCTS=${products[*]}" >> "$GITHUB_OUTPUT"
+    - name: Build Images
+      uses: ./.github/actions/build
+      with:
+        products: ${{ steps.deploy_infra.outputs.PRODUCTS }}
+        push: true
     - name: Show Usage
       run: |
         free -h
@@ -379,7 +368,7 @@ jobs:
 
   deploy_product:
     name: Deploy Product
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'push' && github.repository_owner == 'zncdatadev' }}
     needs: 
       - prepare_product_matrix
@@ -413,58 +402,31 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache docker
-      id: cache-buildx
-      uses: actions/cache@v4
-      with:
-        path: 
-          /tmp/docker-cache
-        key: ${{ runner.os }}-docker-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-docker-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Install jq
       uses: dcarbone/install-jq-action@v2.1.0
     - name: Check version
       run: |
         bash --version
         jq --version
-        docker info
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+        buildah version
+        podman info
     - name: Show Usage
       run: |
         free -h
         df -h
         lsblk
+    - name: Install buildah
+      uses: ./.github/actions/install-buildah
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: Deploy Product
-      run: |
-        set -ex
-
-        . ./.scripts/lib.sh
-
-        PRODUCT="${{ matrix.product }}"
-        echo "PRODUCT from matrix: $PRODUCT"
-        
-        product_name=$(echo $PRODUCT | cut -d':' -f1)
-        product_version=$(echo $PRODUCT | cut -d':' -f2)
-
-        metadata_file="${product_name}/metadata.json"
-
-        # deploy product
-        for property in $(jq -c '.properties[]' $metadata_file); do
-          version=$(echo $property | jq -r '.version')
-          if [ "$version" == "$product_version" ]; then
-            .scripts/build.sh product --push --progress plain --product-version $product_version $product_name
-          fi
-        done
+      uses: ./.github/actions/build
+      with:
+        products: ${{ matrix.product }}
+        push: true
     - name: Show Usage
       run: |
         free -h

--- a/.gitignore
+++ b/.gitignore
@@ -324,3 +324,5 @@ fabric.properties
 
 output.json
 test.sh
+
+!.github/actions/build

--- a/spark-k8s/Dockerfile
+++ b/spark-k8s/Dockerfile
@@ -3,7 +3,7 @@
 ARG JAVA_BASE_VERSION
 ARG JAVA_DEVEL_VERSION
 
-FROM gradle:8 AS gradle-builder
+FROM docker.io/library/gradle:8 AS gradle-builder
 
 ARG PRODUCT_VERSION
 ARG JMX_EXPORTER_VERSION


### PR DESCRIPTION
ref: #55 

Due to the buildah 1.33.7 of ubuntu 24.04 do not support buildah heredoc syntax, we will build image in buildah container by docker env in gh-workflow.

Note: buildah 1.33.0 support heredoc syntax, but it seemed be [patched in ubuntu 24.04](https://github.com/containers/buildah/issues/5474). Github action linux support LTS 24.04. But I can't find this version on debian. In any case, it is not available in ubuntu 24.04. 

When buildah heredoc syntax is available, we can directly build image in the runner.