### PR TITLE
feat(security): add cosign to sign image

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,6 +15,11 @@ inputs:
       Push the image to registry after build.
     required: false
     default: 'false'
+  sign:
+    description: |
+      Sign the image after build.
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -25,9 +30,10 @@ runs:
         BUILDER_NAME: ${{ inputs.builder_name }}
         PRODUCTS: ${{ inputs.products }}
         PUSH: ${{ inputs.push }}
+        SIGN: ${{ inputs.sign }}
       run: |
         set -ex
-        
+        docker exec $BUILDER_NAME ls -alh /usr/local/bin/
         for product in $PRODUCTS; do
           args=(".scripts/build.sh" "product")
 
@@ -46,5 +52,10 @@ runs:
             args+=("--push")
           fi
 
+          if [ "$SIGN" = "true" ]; then
+            args+=("--sign" "cosign")
+          fi
+
           docker exec -w /app $BUILDER_NAME "${args[@]}"
+
         done

--- a/.github/actions/install-buildah/action.yml
+++ b/.github/actions/install-buildah/action.yml
@@ -52,20 +52,35 @@ runs:
         docker run \
           --privileged \
           --name $BUILDER_NAME \
-          -e BUILDAH_ISOLATION=chroot \
-          -e BUILDAH_STORAGE_DRIVER=vfs \
           -e CONTAINER_TOOL_PROVIDER=buildah \
+          -e ACTIONS_ID_TOKEN_REQUEST_TOKEN=$ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+          -e ACTIONS_ID_TOKEN_REQUEST_URL=$ACTIONS_ID_TOKEN_REQUEST_URL \
           -e CI_SCRIPT_DEBUG=true \
-          -e REGISTRY=${REGISTRY} \
           -v $(pwd):/app \
           -d \
           quay.io/buildah/stable:$BUILDAH_VERSION \
             tail -f /dev/null
 
-        # install required tools
-        docker exec $BUILDER_NAME dnf install -y jq
-
         # login to quay.io
         if [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
           docker exec $BUILDER_NAME buildah login "$REGISTRY" --username "$USERNAME" --password "$PASSWORD"
         fi
+
+        # install required tools
+        docker exec $BUILDER_NAME sh -c "
+          set -ex
+
+          # install required tools
+          dnf install -y jq 
+          curl -sSfL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
+          chmod +x /usr/local/bin/cosign
+          cosign version
+
+          # to fix cosign publish with unauthorized error
+          # https://github.com/sigstore/cosign/issues/587#issuecomment-2305367341
+          # if /run/containers/0/auth.json exists, copy it to ~/.docker/config.json
+          if [ -f /run/containers/0/auth.json ]; then
+            mkdir -p /root/.docker/
+            cp /run/containers/0/auth.json /root/.docker/config.json
+          fi
+        "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,23 +67,26 @@ jobs:
         elif [ $GH_EVENT == 'push' ]; then
           BEFORE_COMMIT_SHA=${{ github.event.before }}
           AFTER_COMMIT_SHA=${{ github.sha }}
-          # When push to a new branch, BEFORE_COMMIT_SHA is 0000000000000000000000000000000000000000, so we use previous commit
-          if [ $BEFORE_COMMIT_SHA == '0000000000000000000000000000000000000000' ] || ! git merge-base --is-ancestor $BEFORE_COMMIT_SHA $AFTER_COMMIT_SHA; then
-            echo "Push to a new branch or not a direct push to the branch, find the previous commit or the common ancestor"
-            DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
-            BEFORE_COMMIT_SHA=$(git rev-parse origin/$DEFAULT_BRANCH)
-          fi
 
+          # check if BEFORE_COMMIT_SHA is valid. eg: 
+          #   - push to a new branch, BEFORE_COMMIT_SHA is 0000000000000000000000000000000000000000
+          #   - push --amend in main branch, BEFORE_COMMIT_SHA may be invalid
+          # Or BEFORE_COMMIT_SHA is not an ancestor of AFTER_COMMIT_SHA
+          
+          if ! git cat-file -e $BEFORE_COMMIT_SHA >/dev/null 2>&1; then
+            BEFORE_COMMIT_SHA=$(git rev-parse "$AFTER_COMMIT_SHA"^)
+          fi
         fi
 
-        # save to env
+        echo "Save commit sha to env"
         echo "BEFORE_COMMIT_SHA=$BEFORE_COMMIT_SHA" >> $GITHUB_ENV
         echo "AFTER_COMMIT_SHA=$AFTER_COMMIT_SHA" >> $GITHUB_ENV
-        # save to output
+            
+        echo "BEFORE_COMMIT_SHA=$BEFORE_COMMIT_SHA"
         echo "BEFORE_COMMIT_SHA=$BEFORE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
         echo "AFTER_COMMIT_SHA=$AFTER_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
-        # get updated product
+        echo "Get target product"
         python3 .github/scripts/get_target_product.py \
           --before-sha $BEFORE_COMMIT_SHA \
           --after-sha $AFTER_COMMIT_SHA
@@ -110,6 +113,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: 
       - prepare_updated_product
+    permissions:
+      id-token: write
     steps:
     - name: Show Usage
       run: |
@@ -164,7 +169,6 @@ jobs:
         products=()
         # build infra
         for item in $(echo "${INFRA}" | jq -r '.[]'); do
-            # /app/.scripts/build.sh product $item
             products+=($item)
         done
 
@@ -174,7 +178,6 @@ jobs:
       uses: ./.github/actions/build
       with:
         products: ${{ steps.build_infra.outputs.PRODUCTS }}
-        push: false
     - name: Show Usage
       run: |
         free -h
@@ -225,6 +228,8 @@ jobs:
     name: Test Product
     runs-on: ubuntu-24.04
     needs: prepare_product_matrix
+    permissions:
+      id-token: write
     if: ${{ needs.prepare_product_matrix.outputs.PRODUCT_MATRIX != '[]' }}
     strategy:
       matrix:
@@ -276,7 +281,6 @@ jobs:
       uses: ./.github/actions/build
       with:
         products: ${{ matrix.product }}
-        push: false
     - name: Show Usage
       run: |
         free -h
@@ -289,6 +293,8 @@ jobs:
     needs: 
       - prepare_updated_product
       - test_infra
+    permissions:
+      id-token: write
     if: github.event_name == 'push' && github.repository_owner == 'zncdatadev'
     steps:
     - name: Show Usage
@@ -360,6 +366,7 @@ jobs:
       with:
         products: ${{ steps.deploy_infra.outputs.PRODUCTS }}
         push: true
+        sign: true
     - name: Show Usage
       run: |
         free -h
@@ -374,6 +381,8 @@ jobs:
       - prepare_product_matrix
       - test_product
       - deploy_infra  # already deploy condition
+    permissions:
+      id-token: write
     strategy:
       matrix:
         product: ${{fromJson(needs.prepare_product_matrix.outputs.PRODUCT_MATRIX)}}
@@ -427,6 +436,7 @@ jobs:
       with:
         products: ${{ matrix.product }}
         push: true
+        sign: true
     - name: Show Usage
       run: |
         free -h

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,6 @@ output.json
 test.sh
 
 !.github/actions/build
+
+# ignore suffix: _digest.txt files, it's used for temporary storing the digest of the file
+*_digest.txt

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE
+ARG KUBEDOOP_BASE_VERSION
 
-FROM ${BASE_IMAGE:-quay.io/zncdatadev/kubedoop-base:0.0.1-kubedoop0.0.0-dev}
+FROM quay.io/zncdatadev/kubedoop-base:${KUBEDOOP_BASE_VERSION}-kubedoop0.0.0-dev 
 
 ARG PRODUCT_VERSION
 ARG MAVEN_VERSION

--- a/java-devel/metadata.json
+++ b/java-devel/metadata.json
@@ -4,30 +4,35 @@
     {
       "version": "1.8.0",
       "dependencies": {
+        "kubedoop-base": "1.0.0",
         "maven": "3.6.3"
       }
     },
     {
       "version": "11",
       "dependencies": {
+        "kubedoop-base": "1.0.0",
         "maven": "3.6.3"
       }
     },
     {
       "version": "17",
       "dependencies": {
+        "kubedoop-base": "1.0.0",
         "maven": "3.6.3"
       }
     },
     {
       "version": "21",
       "dependencies": {
+        "kubedoop-base": "1.0.0",
         "maven": "3.6.3"
       }
     },
     {
       "version": "22",
       "dependencies": {
+        "kubedoop-base": "1.0.0",
         "maven": "3.6.3"
       }
     }

--- a/kubedoop-base/Dockerfile
+++ b/kubedoop-base/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.8
 
-FROM registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194
 
 COPY kubedoop/dnf.conf /etc/dnf/dnf.conf
 


### PR DESCRIPTION
ref: https://github.com/zncdatadev/containers/issues/55

Since we are building the container in a container environment with buildah, we need to get the buildah container to support cosign signing and push the signing result to the mirror repository.

We need to do some extra work in the way we use cosign instead of github-action:

1. Install the cosign command in the buildah container so that it can be used to sign the container after it is built.
2. Passing oidc information from the github action environment into the buildah container allows cosign to keyless sign based on github authentication in the buildah container
3. Fixed cosign not being able to use buildah cached authentication information directly in the buildah environment. ref: https://github.com/sigstore/cosign/issues/587#issuecomment-2305367341

Once the heredoc issue with buildah in ubuntu 24.04 environment is fixed, we can simply and easily complete these tasks using only github-action based mode.