### PR TITLE
refactor(java-devel): restrict java version of maven

### DIFF
--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -8,6 +8,7 @@ ARG PRODUCT_VERSION
 ARG MAVEN_VERSION
 
 RUN <<EOT
+    set -ex
     # https://adoptium.net/en-GB/installation/linux/#_centosrhelfedora_instructions
     cat <<EOF > /etc/yum.repos.d/adoptium.repo
 [Adoptium]
@@ -33,7 +34,7 @@ EOF
         krb5-devel \
         libcurl-devel \
         make \
-        maven-openjdk${JAVA_VERSION} \
+        maven \
         openssl-devel \
         patch \
         pkg-config \
@@ -50,7 +51,13 @@ EOF
     microdnf clean all
     rm -rf /var/cache/yum
 
-    java -version
+    # Due to the maven default dependency jdk17, so two versions of jdk are installed if the PRODUCT_VERSION is not 17.
+    # Use alternatives to set the default Java version
+    alternatives --set java /usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk/bin/java
+    alternatives --set javac /usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk/bin/javac
+
+    # smoke test
+    java -version 2>&1 | grep -q "openjdk version \"${PRODUCT_VERSION}." || (echo "Java version mismatch" && exit 1)
 EOT
 
 ENV JAVA_HOME=/usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -5,7 +5,6 @@
 FROM zncdatadev/image/kubedoop-base
 
 ARG PRODUCT_VERSION
-ARG MAVEN_VERSION
 
 RUN <<EOT
     set -ex
@@ -57,7 +56,11 @@ EOF
     alternatives --set javac /usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk/bin/javac
 
     # smoke test
-    java -version 2>&1 | grep -q "openjdk version \"${PRODUCT_VERSION}." || (echo "Java version mismatch" && exit 1)
+    if [ "${PRODUCT_VERSION}" != "8" ]; then
+        java -version 2>&1 | grep -q "openjdk version \"${PRODUCT_VERSION}\." || (echo "Java version mismatch" && exit 1)
+    else
+        java -version 2>&1 | grep -q "openjdk version \"1\.${PRODUCT_VERSION}\." || (echo "Java version mismatch" && exit 1)
+    fi
 EOT
 
 ENV JAVA_HOME=/usr/lib/jvm/temurin-${PRODUCT_VERSION}-jdk

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -33,7 +33,7 @@ EOF
         krb5-devel \
         libcurl-devel \
         make \
-        maven \
+        maven-openjdk${JAVA_VERSION} \
         openssl-devel \
         patch \
         pkg-config \


### PR DESCRIPTION
The maven default use jdk 17, in java-devel:8 container, the java version default is 17. So restrict java version of maven.