### PR TITLE
feat(zookeeper): universal container process management framework (product-first pilot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ go.work
 .idea/**/aws.xml
 
 # Generated files
+bin/
 .idea/**/contentModel.xml
 
 # Sensitive or high-churn files

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ downloads/
 eggs/
 .eggs/
 lib/
+# Framework libraries vendored per product image (product-first rollout).
+# The generic `lib/` rule above (Python build artifacts) would otherwise ignore them.
+!zookeeper/kubedoop/lib/
 lib64/
 parts/
 sdist/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq (,$(shell which yq 2>/dev/null))
 		OS=$(shell uname -s | tr '[:upper:]' '[:lower:]') && \
 		ARCH=$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') && \
 		if [ "$${OS}" = "darwin" ]; then OS="macos"; fi && \
-		curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/latest/download/ya_$${OS}_$${ARCH} ;\
+		curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/latest/download/yq_$${OS}_$${ARCH} ;\
 		chmod +x $(YQ) ;\
 	}
 else

--- a/docs/container-process-management.md
+++ b/docs/container-process-management.md
@@ -268,22 +268,31 @@ stop_process() {
     log_info "Forwarding SIGTERM to main process (PID: $pid)"
     kill -TERM "$pid" 2>/dev/null || true
 
-    # Wait for process to exit (with timeout protection)
-    local elapsed=0
-    while kill -0 "$pid" 2>/dev/null && [[ $elapsed -lt $timeout ]]; do
-        sleep 1
-        elapsed=$((elapsed + 1))
-    done
+    # Reap process to capture exit code. Use a SIGALRM timer for timeout
+    # protection instead of polling with kill -0: a dead-but-unreaped child is
+    # still visible to kill -0 as a zombie, which can add a full timeout delay
+    # even after graceful shutdown has completed.
+    local timed_out=0
+    local shell_pid="$BASHPID"
+    (
+        sleep "$timeout"
+        kill -ALRM "$shell_pid" 2>/dev/null
+    ) &
+    local timer_pid=$!
 
-    # Force kill on timeout
-    if kill -0 "$pid" 2>/dev/null; then
-        log_warn "Main process did not exit in ${timeout}s, sending SIGKILL"
-        kill -KILL "$pid" 2>/dev/null || true
-    fi
+    trap 'timed_out=1; log_warn "Main process did not exit in ${timeout}s, sending SIGKILL"; kill -KILL "$pid" 2>/dev/null || true' SIGALRM
 
-    # Reap process to capture exit code
     wait "$pid" 2>/dev/null
     local rc=$?
+    if [[ "$timed_out" -eq 1 ]]; then
+        wait "$pid" 2>/dev/null
+        rc=$?
+    fi
+
+    trap - SIGALRM
+    kill "$timer_pid" 2>/dev/null || true
+    wait "$timer_pid" 2>/dev/null || true
+
     if [[ $rc -eq 127 ]]; then
         # Not a child of this shell — already reaped, exit code unknown
         STOP_REAPED=0

--- a/docs/container-process-management.md
+++ b/docs/container-process-management.md
@@ -1,6 +1,6 @@
 # Container Process Management Design
 
-> **Status**: Phase 1 (kubedoop-base) implemented. Init system: tini v0.19.0. Pod state and sidecar watchdog deferred.
+> **Status**: Piloting in the **zookeeper** image (product-first rollout, see [Rollout Strategy](#rollout-strategy-product-first)). Init system: tini v0.19.0. Extraction into `kubedoop-base`, pod-state coordination, and the sidecar watchdog are deferred.
 
 ## Design Goals
 
@@ -76,9 +76,9 @@ Kubernetes sends SIGTERM
 |  |  [1] source lib/*.sh                Load libraries      | |
 |  |  [2] run_phase mount/pre-script     Runtime pre-hooks   | |
 |  |  [3] run_lifecycle "$@"             Start + manage      | |
-|  |      ├── trap '' SIGTERM SIGINT     Block signals       | |
+|  |      ├── trap 'defer' SIGTERM SIGINT Defer (not SIG_IGN)| |
 |  |      ├── "$@" & MAIN_PID=$!         Background CMD      | |
-|  |      ├── trap cleanup SIGTERM SIGINT Restore handler    | |
+|  |      ├── trap cleanup SIGTERM SIGINT Arm real handler   | |
 |  |      └── wait $MAIN_PID             Wait for exit       | |
 |  |                                                         | |
 |  |  -- On SIGTERM received (via cleanup) --                 | |
@@ -345,25 +345,54 @@ run_lifecycle() {
     MAIN_PID=""
     EXIT_CODE=0
     _CLEANUP_RUNNING=0
+    _PENDING_SIGNAL=0
 
-    # Block signals during process start to prevent cleanup() with empty MAIN_PID
-    trap '' SIGTERM SIGINT
+    # Defer signals during process start to close the race where SIGTERM arrives
+    # before MAIN_PID is captured (which would run cleanup() with an empty PID).
+    #
+    # CRITICAL: use a real handler that records a pending flag — NOT `trap ''`.
+    # `trap '' SIGTERM` installs SIG_IGN, which is INHERITED by the backgrounded
+    # child across fork/exec. A non-interactive child shell cannot re-trap a
+    # signal that was ignored on entry, so the child (and any SIGTERM handler it
+    # installs, e.g. a product entrypoint) would silently ignore graceful
+    # shutdown — the exact opposite of this framework's guarantee. A real trap
+    # handler is reset to SIG_DFL in the execed child, so the child receives
+    # SIGTERM normally and may install its own handler.
+    trap '_PENDING_SIGNAL=1' SIGTERM SIGINT
 
     # Start process and capture PID atomically (same logical line as backgrounding)
     "$@" & MAIN_PID=$!
 
-    # Restore signal handler immediately after PID capture — minimizes race window
+    # Swap the deferring handler for the real cleanup handler.
     trap cleanup SIGTERM SIGINT
 
     log_info "Main process started (PID: $MAIN_PID): $*"
 
-    # Wait for main process to exit
-    wait $MAIN_PID || EXIT_CODE=$?
-
-    # Run cleanup (if not already triggered by signal trap)
-    if [[ "${_CLEANUP_RUNNING:-0}" -ne 1 ]]; then
+    # If a signal arrived during the start window, the deferring handler recorded
+    # it. Run cleanup now (with a valid MAIN_PID) instead of waiting.
+    if [[ "$_PENDING_SIGNAL" -eq 1 ]]; then
+        log_info "Signal received during startup, initiating shutdown"
         cleanup
     fi
+
+    # Wait for the main process to exit.
+    #
+    # Two paths reach this point:
+    #   Normal exit — main process exits on its own; wait returns its real code.
+    #   Signal path — SIGTERM/SIGINT arrives during wait, firing the cleanup()
+    #                 trap. cleanup() reaps the child and sets EXIT_CODE to the
+    #                 real reaped code. The interrupted wait then returns
+    #                 128+signum (e.g. 143 for SIGTERM), which must NOT clobber
+    #                 the real exit code cleanup() already captured.
+    local rc=0
+    wait "$MAIN_PID" || rc=$?
+
+    if [[ "${_CLEANUP_RUNNING:-0}" -ne 1 ]]; then
+        # Normal exit path: capture the real exit code, then run cleanup hooks.
+        EXIT_CODE=$rc
+        cleanup
+    fi
+    # Signal path: cleanup() already ran and set EXIT_CODE — leave it intact.
 }
 ```
 
@@ -929,7 +958,34 @@ spec:
 
 For K8s >= 1.28, the native sidecar handles start/stop ordering. State files provide early flush triggering (the sidecar starts draining before K8s even sends SIGTERM), which reduces log loss during shutdown. State files also provide visibility (PID, exit code) for debugging.
 
+## Rollout Strategy: Product-First
+
+The end-state design deploys the framework once in `kubedoop-base` so every image
+inherits it (see [kubedoop-base/Dockerfile Integration](#kubedoop-basedockerfile-integration)).
+However, **any change to `kubedoop-base` rebuilds every downstream image** in the PR
+pipeline, which is prohibitively slow while the framework itself is still being iterated on.
+
+To avoid that, the framework is rolled out **product-first**:
+
+1. **Pilot in a single product image** — the framework source (`lib/`, `bin/entrypoint.sh`)
+   is vendored under the product directory (e.g. `zookeeper/kubedoop/{lib,bin}`), and the
+   tini install + framework deploy steps live in that product's `Dockerfile`. Only that one
+   image rebuilds. **zookeeper** is the first pilot (a simple, zero-script product).
+2. **Repeat for a few more products** to validate the contract across shapes (zero-script,
+   product-entrypoint, complex-entrypoint).
+3. **Extract upward into `kubedoop-base`** once proven. At that point the per-product
+   `lib/`, `bin/`, and Dockerfile steps are removed in favour of inheritance — this is the
+   original Phase 1 below, executed last instead of first.
+
+The framework contents are identical in both placements; only the *layer* they live in
+changes. This means a product piloting the framework today needs no code changes when the
+extraction lands — its `Dockerfile` simply drops the now-inherited steps.
+
 ## Gradual Migration Path
+
+> **Note**: Under the [product-first rollout](#rollout-strategy-product-first), Phase 1 is
+> executed **last** (extraction into `kubedoop-base`), after the framework has been piloted
+> in individual product images. The phases below describe the end-state layering.
 
 ### Phase 1: Infrastructure
 
@@ -1031,7 +1087,7 @@ The security model protects the **container image** (framework + application), n
 
 **What is NOT protected**: Writable paths explicitly mounted by the operator (log directories, PVC data, hostPath mounts). This is by design — the operator controls the trust boundary.
 
-**State file protection**: The entrypoint cleans stale/fake state files after pre-scripts run but before the main process starts (see `rm -f` in entrypoint.sh). This prevents injected pre-scripts from poisoning sidecar coordination with fake `main.status` or `main.pid` values. Pre-scripts are trusted not to write state files between the cleanup and the real state writes (a sub-millisecond window).
+**State file protection** (deferred, ships with pod-state coordination): once state files are written, the entrypoint will clean stale/fake state files after pre-scripts run but before the main process starts (a `rm -f` step in entrypoint.sh). This prevents injected pre-scripts from poisoning sidecar coordination with fake `main.status` or `main.pid` values. Pre-scripts are trusted not to write state files between the cleanup and the real state writes (a sub-millisecond window). Until `lib/pod-state.sh` is deployed, no state files are written and this cleanup is not present.
 
 ## Architecture Relationship
 

--- a/zookeeper/AGENTS.md
+++ b/zookeeper/AGENTS.md
@@ -26,6 +26,10 @@ See `versions.yaml` for current values. Structure:
 - `kubedoop/jmx/config/config.yaml` — ZooKeeper-specific rules: ReplicatedServer patterns (with replicaId label), standalone patterns, InMemoryDataTree pattern (with memberType label)
 ### Custom Scripts
 - `kubedoop/patches/apply_patches.sh` — applies .patch files from version subdirectories
+- `kubedoop/bin/entrypoint.sh` — universal entrypoint framework pilot for process lifecycle management
+- `kubedoop/lib/` — entrypoint framework libraries for logging, hook discovery, and signal handling
+- `tests/source-entrypoint-framework.sh` — source-level shell tests for the vendored entrypoint framework
+- `tests/image-entrypoint-framework.sh` — image-level tests for built entrypoint behavior
 
 ## Dependencies
 - Uses at build time: java-devel (Java 11)
@@ -34,6 +38,10 @@ See `versions.yaml` for current values. Structure:
 
 ## Key Files
 - `Dockerfile` — simplest Java build: single Maven stage with `-Pfull-build`, excludes zookeeper-client-c, log4shell patch, tarball rename (-bin suffix)
+- `kubedoop/bin/entrypoint.sh` — universal entrypoint wrapper used as the image entrypoint via tini
+- `kubedoop/lib/` — vendored framework libraries for the product-first rollout
+- `tests/source-entrypoint-framework.sh` — local source-level verification for framework lifecycle behavior
+- `tests/image-entrypoint-framework.sh` — post-build image verification for entrypoint wiring, hooks, and signal behavior
 - `kubedoop/patches/3.9.2/` — version-specific patches
 - `kubedoop/patches/apply_patches.sh` — patch application script
 - `kubedoop/jmx/config/config.yaml` — ZooKeeper JMX rules

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -73,7 +73,7 @@ RUN <<EOF
     curl -sSfL -o /usr/local/bin/log4shell \
         https://github.com/lunasec-io/lunasec/releases/download/v1.6.1-log4shell/log4shell_1.6.1-log4shell_Linux_${ARCH}
     chmod +x /usr/local/bin/log4shell
-    /usr/local/bin/log4shell patch --backup --force-patch --json hadoop-${PRODUCT_VERSION}
+    /usr/local/bin/log4shell patch --backup --force-patch --json /kubedoop/zookeeper
 EOF
 
 

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -81,15 +81,49 @@ EOF
 FROM zncdatadev/image/java-base
 
 ARG PRODUCT_VERSION
+ARG TARGETARCH
 
 WORKDIR /kubedoop
 
 COPY --from=zookeeper-builder --chown=kubedoop:kubedoop /kubedoop/ /kubedoop/
 
+# Install init system
+# tini: lightweight init, signal forwarding to direct child, zombie reaping
+# Not available in UBI 9 repos — download static binary from GitHub releases
+# SHA256 checksums are hardcoded in the verification step to prevent --build-arg override
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETARCH} /tmp/tini
+RUN <<EOF
+    set -e
+    case "${TARGETARCH}" in
+        arm64)  expected_sha="eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9" ;;
+        amd64)  expected_sha="c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee" ;;
+        *)      echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;;
+    esac
+    echo "${expected_sha}  /tmp/tini" | sha256sum -c
+    mv /tmp/tini /usr/bin/tini
+    chmod +x /usr/bin/tini
+EOF
+
+# Deploy universal entrypoint framework
+# Framework files: root-owned, world-readable/executable, NOT writable by kubedoop
+COPY --chown=root:root kubedoop/lib/ /kubedoop/lib/
+COPY --chown=root:root kubedoop/bin/entrypoint.sh /kubedoop/bin/entrypoint.sh
+RUN chmod -R 0755 /kubedoop/lib/ /kubedoop/bin/ \
+    && mkdir -p /kubedoop/mount/pre-script /kubedoop/mount/post-script \
+    && chown -R root:root /kubedoop/mount/ \
+    && mkdir -p /kubedoop/run \
+    && chown kubedoop:kubedoop /kubedoop/run \
+    && chmod 1775 /kubedoop/run
+
 ENV ZOOKEEPER_HOME=/kubedoop/zookeeper
 ENV PATH="$ZOOKEEPER_HOME/bin:$PATH"
 
 WORKDIR /kubedoop/zookeeper
+
 USER kubedoop
 
+# Init process as PID 1
+# No -g flag: tini forwards signals only to direct child process.
+# The entrypoint.sh manages signal propagation explicitly via trap.
+ENTRYPOINT ["tini", "--", "/kubedoop/bin/entrypoint.sh"]
 CMD ["bin/zkServer.sh", "start-foreground", "config/zoo_sample.cfg"]

--- a/zookeeper/kubedoop/bin/entrypoint.sh
+++ b/zookeeper/kubedoop/bin/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# /kubedoop/bin/entrypoint.sh -- Universal container entrypoint
+#
+# Note: Uses set -uo pipefail WITHOUT -e.
+# Signal-aware scripts must not use set -e because trap handlers
+# and set -e interact unpredictably. All error handling is explicit.
+#
+# Lifecycle logic (cleanup, signal handling) is in lib/signal.sh.
+# This script is a thin orchestrator: config → load → pre-script → lifecycle → exit.
+set -uo pipefail
+
+# Paths are locked at build time — not overridable via environment variables
+readonly KUBEDOOP_HOME="/kubedoop"
+readonly KUBEDOOP_MOUNT_DIR="${KUBEDOOP_HOME}/mount"
+readonly KUBEDOOP_RUN_DIR="${KUBEDOOP_HOME}/run"
+
+# Graceful shutdown timeout (seconds). Validated and locked at startup.
+KUBEDOOP_KILL_TIMEOUT="${KUBEDOOP_KILL_TIMEOUT:-30}"
+if ! [[ "$KUBEDOOP_KILL_TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[kubedoop] [ERROR] KUBEDOOP_KILL_TIMEOUT must be a positive integer >= 1, got: $KUBEDOOP_KILL_TIMEOUT" >&2
+    exit 1
+fi
+readonly KUBEDOOP_KILL_TIMEOUT
+
+# Ensure run directory exists with correct permissions
+mkdir -p "${KUBEDOOP_RUN_DIR}"
+
+# Load common libraries.
+# Libraries load in glob sort order. If a library depends on another,
+# it must document this requirement (e.g., signal.sh depends on log.sh and run-phase.sh).
+for lib in "${KUBEDOOP_HOME}/lib/"*.sh; do
+    if [[ -f "$lib" ]]; then
+        # shellcheck source=/dev/null
+        source "$lib"
+    fi
+done
+
+log_info "Entrypoint starting: $*"
+
+# --- Phase 1: Runtime pre-script hooks (auto-discovered from mount) ---
+# Note: pre-script failure prevents main process startup (fail-fast).
+# Operators must test injected scripts in non-production environments first.
+if ! run_phase "pre-script" "${KUBEDOOP_MOUNT_DIR}/pre-script"; then
+    log_error "Pre-script phase failed, aborting startup"
+    exit 1
+fi
+
+# --- Phase 2: Start main process and manage lifecycle ---
+if [[ $# -eq 0 ]]; then
+    log_error "No command specified"
+    exit 1
+fi
+
+run_lifecycle "$@"
+exit $EXIT_CODE

--- a/zookeeper/kubedoop/lib/log.sh
+++ b/zookeeper/kubedoop/lib/log.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# /kubedoop/lib/log.sh -- Unified log output
+#
+# Provides structured logging with ISO 8601 timestamps.
+# Log prefix is configurable via __KUBEDOOP_LOG_PREFIX (default: "kubedoop").
+# Debug output is gated by KUBEDOOP_DEBUG=true.
+
+__KUBEDOOP_LOG_PREFIX="${__KUBEDOOP_LOG_PREFIX:-kubedoop}"
+
+# Internal log formatter. Strips control characters to prevent log injection.
+#
+# Arguments:
+#   $1    - Log level (INFO, WARN, ERROR, DEBUG)
+#   $2..  - Message strings
+#
+# Output:
+#   stdout - Formatted log line: "[TIMESTAMP] [PREFIX] [LEVEL] MESSAGE"
+_kubedoop_log() {
+    local level="$1"; shift
+    local timestamp
+    timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    # Sanitize: strip control characters to prevent log injection
+    local msg
+    msg=$(printf '%s' "$*" | tr -d '[:cntrl:]')
+    printf "[%s] [%s] [%s] %s\n" "$timestamp" "$__KUBEDOOP_LOG_PREFIX" "$level" "$msg"
+}
+
+# Log at INFO level to stdout.
+#
+# Arguments:
+#   $@ - Message strings
+log_info()  { _kubedoop_log "INFO"  "$@"; }
+
+# Log at WARN level to stderr.
+#
+# Arguments:
+#   $@ - Message strings
+log_warn()  { _kubedoop_log "WARN"  "$@" >&2; }
+
+# Log at ERROR level to stderr.
+#
+# Arguments:
+#   $@ - Message strings
+log_error() { _kubedoop_log "ERROR" "$@" >&2; }
+
+# Log at DEBUG level to stdout. No-op unless KUBEDOOP_DEBUG=true.
+#
+# Arguments:
+#   $@ - Message strings
+#
+# Returns:
+#   0 - Always (no error when debug is disabled)
+log_debug() {
+    if [[ "${KUBEDOOP_DEBUG:-false}" == "true" ]]; then
+        _kubedoop_log "DEBUG" "$@"
+    fi
+}

--- a/zookeeper/kubedoop/lib/run-phase.sh
+++ b/zookeeper/kubedoop/lib/run-phase.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# /kubedoop/lib/run-phase.sh -- Script auto-discovery and execution
+#
+# Discovers and executes .sh scripts in a directory, sorted by filename.
+# Used for pre-script and post-script lifecycle phases.
+
+# Discover executable .sh scripts in a directory, sorted by filename.
+#
+# Arguments:
+#   $1 - Directory path to scan
+#
+# Output:
+#   stdout - Null-delimited sorted list of matching script paths, empty if none found
+#
+# Returns:
+#   0 - Always (missing directory is not an error)
+discover_scripts() {
+    local phase_dir="$1"
+
+    if [[ ! -d "$phase_dir" ]]; then
+        return 0
+    fi
+
+    # Only match .sh files that have any execute bit set (owner, group, or other).
+    # Note: -executable is GNU find specific (not BSD/macOS). Acceptable here since
+    # the target environment is ubi9-minimal (Linux, GNU findutils).
+    # With ConfigMap defaultMode: 0755, this correctly matches all executable scripts.
+    # SECURITY: Only execute scripts owned by root (uid 0) to prevent injection
+    # from non-root writable volumes (emptyDir, PVC, hostPath).
+    find "$phase_dir" -maxdepth 1 -type f -name '*.sh' -executable \
+        -uid 0 -print0 \
+        | sort -z
+}
+
+# Execute all discovered scripts in a phase directory sequentially.
+# Script execution order is determined by filename sort order.
+# First script failure aborts the phase immediately.
+#
+# Arguments:
+#   $1 - Phase name (for logging, e.g., "pre-script", "post-script")
+#   $2 - Directory containing executable .sh scripts
+#
+# Returns:
+#   0 - All scripts succeeded, or no scripts found
+#   1 - A script failed, or script discovery failed
+run_phase() {
+    local phase_name="$1"
+    local phase_dir="$2"
+
+    if [[ ! -d "$phase_dir" ]]; then
+        return 0
+    fi
+
+    local count=0
+    local found_any=false
+
+    while IFS= read -r -d '' script; do
+        found_any=true
+        local name
+        name=$(basename "$script")
+        log_info "Phase '$phase_name': running $name"
+        count=$((count + 1))
+
+        local rc=0
+        "$script" || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            log_error "Phase '$phase_name': $name failed with exit code $rc"
+            return 1
+        fi
+    done < <(discover_scripts "$phase_dir")
+
+    if [[ "$found_any" == false ]]; then
+        log_info "Phase '$phase_name': no scripts found in $phase_dir"
+        return 0
+    fi
+
+    log_info "Phase '$phase_name': completed ($count scripts)"
+    return 0
+}

--- a/zookeeper/kubedoop/lib/signal.sh
+++ b/zookeeper/kubedoop/lib/signal.sh
@@ -54,22 +54,31 @@ stop_process() {
     log_info "Forwarding SIGTERM to main process (PID: $pid)"
     kill -TERM "$pid" 2>/dev/null || true
 
-    # Wait for process to exit (with timeout protection)
-    local elapsed=0
-    while kill -0 "$pid" 2>/dev/null && [[ $elapsed -lt $timeout ]]; do
-        sleep 1
-        elapsed=$((elapsed + 1))
-    done
+    # Reap process to capture exit code. Use a SIGALRM timer for timeout
+    # protection instead of polling with kill -0: a dead-but-unreaped child is
+    # still visible to kill -0 as a zombie, which can add a full timeout delay
+    # even after graceful shutdown has completed.
+    local timed_out=0
+    local shell_pid="$BASHPID"
+    (
+        sleep "$timeout"
+        kill -ALRM "$shell_pid" 2>/dev/null
+    ) &
+    local timer_pid=$!
 
-    # Force kill on timeout
-    if kill -0 "$pid" 2>/dev/null; then
-        log_warn "Main process did not exit in ${timeout}s, sending SIGKILL"
-        kill -KILL "$pid" 2>/dev/null || true
-    fi
+    trap 'timed_out=1; log_warn "Main process did not exit in ${timeout}s, sending SIGKILL"; kill -KILL "$pid" 2>/dev/null || true' SIGALRM
 
-    # Reap process to capture exit code
     wait "$pid" 2>/dev/null
     local rc=$?
+    if [[ "$timed_out" -eq 1 ]]; then
+        wait "$pid" 2>/dev/null
+        rc=$?
+    fi
+
+    trap - SIGALRM
+    kill "$timer_pid" 2>/dev/null || true
+    wait "$timer_pid" 2>/dev/null || true
+
     if [[ $rc -eq 127 ]]; then
         # Not a child of this shell — already reaped, exit code unknown
         STOP_REAPED=0

--- a/zookeeper/kubedoop/lib/signal.sh
+++ b/zookeeper/kubedoop/lib/signal.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# /kubedoop/lib/signal.sh -- Process lifecycle management
+#
+# Provides graceful process termination, cleanup orchestration,
+# and full lifecycle management for the universal entrypoint.
+#
+# Depends on: lib/log.sh, lib/run-phase.sh (loaded via glob in entrypoint)
+#
+# Required global variables (set by entrypoint before calling run_lifecycle):
+#   KUBEDOOP_KILL_TIMEOUT - Max seconds to wait before SIGKILL (readonly)
+#   KUBEDOOP_MOUNT_DIR    - Path to mount directory (readonly)
+
+# Terminate a process gracefully with timeout escalation.
+#
+# Steps:
+#   1. If process is alive, send SIGTERM
+#   2. Wait up to timeout seconds for process to exit
+#   3. Escalate to SIGKILL on timeout
+#   4. Reap process to capture exit code and prevent zombies
+#
+# Arguments:
+#   $1 - PID to terminate
+#   $2 - Timeout in seconds before SIGKILL escalation
+#
+# Side effects:
+#   Sets STOP_EXIT_CODE to the reaped exit code (empty if PID is empty or already reaped)
+#   Sets STOP_REAPED=1 if the process was reaped, 0 if no PID or already reaped
+stop_process() {
+    local pid="$1"
+    local timeout="$2"
+
+    STOP_EXIT_CODE=""
+    STOP_REAPED=0
+
+    # Nothing to do if no PID
+    if [[ -z "$pid" ]]; then
+        return 0
+    fi
+
+    # Process already dead — try reap in case of signal path (interrupted wait)
+    if ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid" 2>/dev/null
+        local rc=$?
+        if [[ $rc -eq 127 ]]; then
+            # Not a child of this shell — already reaped, exit code unknown
+            STOP_REAPED=0
+        else
+            STOP_EXIT_CODE=$rc
+            STOP_REAPED=1
+        fi
+        return 0
+    fi
+
+    log_info "Forwarding SIGTERM to main process (PID: $pid)"
+    kill -TERM "$pid" 2>/dev/null || true
+
+    # Wait for process to exit (with timeout protection)
+    local elapsed=0
+    while kill -0 "$pid" 2>/dev/null && [[ $elapsed -lt $timeout ]]; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    # Force kill on timeout
+    if kill -0 "$pid" 2>/dev/null; then
+        log_warn "Main process did not exit in ${timeout}s, sending SIGKILL"
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+
+    # Reap process to capture exit code
+    wait "$pid" 2>/dev/null
+    local rc=$?
+    if [[ $rc -eq 127 ]]; then
+        # Not a child of this shell — already reaped, exit code unknown
+        STOP_REAPED=0
+    else
+        STOP_EXIT_CODE=$rc
+        STOP_REAPED=1
+    fi
+}
+
+# Graceful shutdown handler. Invoked via SIGTERM/SIGINT trap by run_lifecycle.
+#
+# Steps:
+#   1. Guard against re-entrant execution
+#   2. Disarm signal traps to prevent nested handler execution
+#   3. Stop main process (SIGTERM → wait → SIGKILL escalation)
+#   4. Capture actual exit code from reap
+#   5. Run post-script phase hooks
+#
+# Environment:
+#   MAIN_PID              - PID of the main process (set by run_lifecycle)
+#   KUBEDOOP_KILL_TIMEOUT - Max seconds to wait before SIGKILL (readonly)
+#
+# Returns:
+#   0 - Always (best-effort cleanup, errors are logged but not propagated)
+cleanup() {
+    # Prevent re-entrant execution (trap + fallthrough race)
+    if [[ "${_CLEANUP_RUNNING:-0}" -eq 1 ]]; then
+        return 0
+    fi
+    _CLEANUP_RUNNING=1
+
+    # Disarm signal traps during cleanup to prevent nested handler execution
+    trap - SIGTERM SIGINT
+
+    log_info "Starting shutdown cleanup"
+
+    stop_process "$MAIN_PID" "$KUBEDOOP_KILL_TIMEOUT"
+
+    # Capture real exit code if process was reaped during signal path
+    if [[ "$STOP_REAPED" -eq 1 && -n "$STOP_EXIT_CODE" ]]; then
+        EXIT_CODE="$STOP_EXIT_CODE"
+    fi
+
+    log_info "Main process stopped"
+
+    # Phase: Runtime post-script hooks (auto-discovered from mount)
+    run_phase "post-script" "${KUBEDOOP_MOUNT_DIR}/post-script" || true
+
+    log_info "Shutdown complete"
+}
+
+# Start main process and manage its full lifecycle.
+#
+# This is the core lifecycle function that:
+#   - Blocks signals during process start (prevents empty PID race)
+#   - Backgrounds the command and captures PID
+#   - Restores signal handler immediately after PID capture (minimizes race window)
+#   - Waits for process exit (normal or signal-triggered)
+#   - Runs cleanup on exit
+#
+# Sets EXIT_CODE global to the process exit code on return.
+#
+# Arguments:
+#   $@ - Command and arguments to run as the main process
+run_lifecycle() {
+    MAIN_PID=""
+    EXIT_CODE=0
+    _CLEANUP_RUNNING=0
+    _PENDING_SIGNAL=0
+
+    # Defer signals during process start to close the race where SIGTERM arrives
+    # before MAIN_PID is captured (which would run cleanup() with an empty PID).
+    #
+    # CRITICAL: use a real handler that records a pending flag — NOT `trap ''`.
+    # `trap '' SIGTERM` installs SIG_IGN, which is INHERITED by the backgrounded
+    # child across fork/exec. A non-interactive child shell cannot re-trap a
+    # signal that was ignored on entry, so the child (and any SIGTERM handler it
+    # installs, e.g. a product entrypoint) would silently ignore graceful
+    # shutdown — the exact opposite of this framework's guarantee. A real trap
+    # handler is reset to SIG_DFL in the execed child, so the child receives
+    # SIGTERM normally and may install its own handler.
+    trap '_PENDING_SIGNAL=1' SIGTERM SIGINT
+
+    # Start process and capture PID atomically (same logical line as backgrounding)
+    "$@" & MAIN_PID=$!
+
+    # Swap the deferring handler for the real cleanup handler.
+    trap cleanup SIGTERM SIGINT
+
+    log_info "Main process started (PID: $MAIN_PID): $*"
+
+    # If a signal arrived during the start window, the deferring handler recorded
+    # it. Run cleanup now (with a valid MAIN_PID) instead of waiting.
+    if [[ "$_PENDING_SIGNAL" -eq 1 ]]; then
+        log_info "Signal received during startup, initiating shutdown"
+        cleanup
+    fi
+
+    # Wait for the main process to exit.
+    #
+    # Two paths reach this point:
+    #   Normal exit — main process exits on its own; wait returns its real code.
+    #   Signal path — SIGTERM/SIGINT arrives during wait, firing the cleanup()
+    #                 trap. cleanup() reaps the child and sets EXIT_CODE to the
+    #                 real reaped code. The interrupted wait then returns
+    #                 128+signum (e.g. 143 for SIGTERM), which must NOT clobber
+    #                 the real exit code cleanup() already captured.
+    local rc=0
+    wait "$MAIN_PID" || rc=$?
+
+    if [[ "${_CLEANUP_RUNNING:-0}" -ne 1 ]]; then
+        # Normal exit path: capture the real exit code, then run cleanup hooks.
+        EXIT_CODE=$rc
+        cleanup
+    fi
+    # Signal path: cleanup() already ran and set EXIT_CODE — leave it intact.
+}

--- a/zookeeper/tests/README.md
+++ b/zookeeper/tests/README.md
@@ -1,0 +1,32 @@
+# ZooKeeper Entrypoint Tests
+
+This directory contains lightweight tests for the zookeeper entrypoint framework.
+
+## Source behavior test
+
+Run this before or after an image build when changing `zookeeper/kubedoop/lib/*.sh`:
+
+```bash
+zookeeper/tests/source-entrypoint-framework.sh
+```
+
+This sources the framework libraries directly from the working tree. It validates
+library behavior only; it does not prove the final image wiring.
+
+## Image behavior test
+
+Run this after `make zookeeper-build`:
+
+```bash
+zookeeper/tests/image-entrypoint-framework.sh
+```
+
+Or pass an explicit image:
+
+```bash
+zookeeper/tests/image-entrypoint-framework.sh quay.io/zncdatadev/zookeeper:3.9.3-kubedoop0.0.0-dev
+```
+
+This runs containers from the built image and validates the final image wiring:
+entrypoint files, runtime user, exit-code propagation, root-owned runtime hooks,
+and signal forwarding through tini and `/kubedoop/bin/entrypoint.sh`.

--- a/zookeeper/tests/image-entrypoint-framework.sh
+++ b/zookeeper/tests/image-entrypoint-framework.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Validate the built zookeeper image's entrypoint framework wiring.
+#
+# This is an image-level companion to source-entrypoint-framework.sh. It should
+# be run after `make zookeeper-build` and tests the final container behavior.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PRODUCT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+REPO_DIR=$(cd "${PRODUCT_DIR}/.." && pwd)
+
+DEFAULT_REGISTRY="${REGISTRY:-quay.io/zncdatadev}"
+DEFAULT_KUBEDOOP_VERSION="${KUBEDOOP_VERSION:-0.0.0-dev}"
+DEFAULT_PRODUCT_VERSION="3.9.3"
+if [[ -f "${PRODUCT_DIR}/versions.yaml" ]]; then
+    DEFAULT_PRODUCT_VERSION=$(awk '
+        $1 == "-" && $2 == "product:" {
+            print $3
+            exit
+        }
+        $1 == "product:" {
+            print $2
+            exit
+        }
+    ' "${PRODUCT_DIR}/versions.yaml")
+fi
+
+IMAGE="${1:-${DEFAULT_REGISTRY}/zookeeper:${DEFAULT_PRODUCT_VERSION}-kubedoop${DEFAULT_KUBEDOOP_VERSION}}"
+TMP_DIR=$(mktemp -d)
+TEST_IMAGE=""
+CONTAINER_IDS=()
+
+cleanup() {
+    local cid
+    for cid in "${CONTAINER_IDS[@]}"; do
+        docker rm -f "$cid" >/dev/null 2>&1 || true
+    done
+    if [[ -n "$TEST_IMAGE" ]]; then
+        docker image rm "$TEST_IMAGE" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "not ok - $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "ok - $*"
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local message="$3"
+
+    if ! grep -Fq "$needle" <<<"$haystack"; then
+        echo "$haystack" >&2
+        fail "$message"
+    fi
+}
+
+wait_for_log() {
+    local cid="$1"
+    local pattern="$2"
+    local timeout="${3:-10}"
+    local elapsed=0
+
+    while [[ $elapsed -lt $timeout ]]; do
+        if docker logs "$cid" 2>&1 | grep -Fq "$pattern"; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    docker logs "$cid" 2>&1 || true
+    return 1
+}
+
+run_expect_status() {
+    local expected="$1"
+    shift
+
+    local rc=0
+    "$@"
+    rc=$?
+
+    [[ "$rc" -eq "$expected" ]] || fail "expected exit code ${expected}, got ${rc}: $*"
+}
+
+test_image_exists() {
+    docker image inspect "$IMAGE" >/dev/null 2>&1 || fail "image not found locally: ${IMAGE}"
+    pass "image exists locally: ${IMAGE}"
+}
+
+test_entrypoint_metadata() {
+    local metadata
+    metadata=$(docker image inspect \
+        --format '{{json .Config.Entrypoint}} {{json .Config.Cmd}} {{.Config.User}}' \
+        "$IMAGE")
+
+    assert_contains "$metadata" '["tini","--","/kubedoop/bin/entrypoint.sh"]' "unexpected image ENTRYPOINT"
+    assert_contains "$metadata" '["bin/zkServer.sh","start-foreground","config/zoo_sample.cfg"]' "unexpected image CMD"
+    assert_contains "$metadata" 'kubedoop' "unexpected image USER"
+    pass "image metadata wires tini and the universal entrypoint"
+}
+
+test_runtime_files_and_user() {
+    docker run --rm --entrypoint /bin/bash "$IMAGE" -c '
+        set -euo pipefail
+        test "$(id -un)" = "kubedoop"
+        test -x /usr/bin/tini
+        test -x /kubedoop/bin/entrypoint.sh
+        test -x /kubedoop/lib/log.sh
+        test -x /kubedoop/lib/run-phase.sh
+        test -x /kubedoop/lib/signal.sh
+        test "$(stat -c "%u:%a" /kubedoop/bin/entrypoint.sh)" = "0:755"
+        test "$(stat -c "%u:%a" /kubedoop/lib/signal.sh)" = "0:755"
+        test -w /kubedoop/run
+    ' || fail "runtime file layout or permissions are invalid"
+
+    pass "runtime files, ownership, and kubedoop user are valid"
+}
+
+test_exit_code_propagation() {
+    run_expect_status 7 docker run --rm "$IMAGE" bash -c 'exit 7'
+    pass "entrypoint preserves main process exit code"
+}
+
+build_hook_test_image() {
+    TEST_IMAGE="zookeeper-entrypoint-test:$(date +%s)-$$"
+    mkdir -p "${TMP_DIR}/hooks"
+
+    cat >"${TMP_DIR}/hooks/10-pre.sh" <<'EOF'
+#!/bin/bash
+set -uo pipefail
+echo pre-hook > /kubedoop/run/pre-hook
+echo TEST_PRE_HOOK_RAN
+EOF
+
+    cat >"${TMP_DIR}/hooks/10-post.sh" <<'EOF'
+#!/bin/bash
+set -uo pipefail
+test -f /kubedoop/run/pre-hook
+echo TEST_POST_HOOK_RAN
+EOF
+
+    chmod 0755 "${TMP_DIR}/hooks/10-pre.sh" "${TMP_DIR}/hooks/10-post.sh"
+
+    cat >"${TMP_DIR}/Dockerfile" <<EOF
+FROM ${IMAGE}
+USER root
+COPY --chown=root:root hooks/10-pre.sh /kubedoop/mount/pre-script/10-pre.sh
+COPY --chown=root:root hooks/10-post.sh /kubedoop/mount/post-script/10-post.sh
+RUN chmod 0755 /kubedoop/mount/pre-script/10-pre.sh /kubedoop/mount/post-script/10-post.sh
+USER kubedoop
+EOF
+
+    docker build -q -t "$TEST_IMAGE" "$TMP_DIR" >/dev/null || fail "failed to build hook test image"
+}
+
+test_root_owned_hooks_execute() {
+    build_hook_test_image
+
+    local output
+    output=$(docker run --rm "$TEST_IMAGE" bash -c '
+        test -f /kubedoop/run/pre-hook
+        echo TEST_MAIN_RAN
+    ' 2>&1) || {
+        echo "$output" >&2
+        fail "root-owned hook image run failed"
+    }
+
+    assert_contains "$output" "TEST_PRE_HOOK_RAN" "pre hook did not run"
+    assert_contains "$output" "TEST_MAIN_RAN" "main command did not run after pre hook"
+    assert_contains "$output" "TEST_POST_HOOK_RAN" "post hook did not run"
+    pass "root-owned pre/post hooks execute in the final image"
+}
+
+test_sigterm_is_forwarded() {
+    local cid
+    cid=$(docker run -d -e KUBEDOOP_KILL_TIMEOUT=2 "$IMAGE" bash -c '
+        trap "echo TEST_CHILD_TERM; exit 42" TERM
+        echo TEST_CHILD_READY
+        while :; do sleep 1; done
+    ') || fail "failed to start signal test container"
+    CONTAINER_IDS+=("$cid")
+
+    wait_for_log "$cid" "TEST_CHILD_READY" 10 || fail "signal test container did not become ready"
+    docker stop -t 5 "$cid" >/dev/null || fail "docker stop failed for signal test container"
+
+    local exit_code
+    exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$cid" 2>/dev/null || true)
+    [[ "$exit_code" == "42" ]] || fail "expected container exit code 42 after forwarded SIGTERM, got ${exit_code}"
+
+    local logs
+    logs=$(docker logs "$cid" 2>&1 || true)
+    assert_contains "$logs" "TEST_CHILD_TERM" "child did not log SIGTERM handling"
+    pass "SIGTERM reaches the main process through tini and the entrypoint"
+}
+
+test_sigkill_after_timeout() {
+    local cid
+    cid=$(docker run -d -e KUBEDOOP_KILL_TIMEOUT=1 "$IMAGE" bash -c '
+        trap "" TERM
+        echo TEST_IGNORE_READY
+        while :; do sleep 1; done
+    ') || fail "failed to start SIGKILL escalation test container"
+    CONTAINER_IDS+=("$cid")
+
+    wait_for_log "$cid" "TEST_IGNORE_READY" 10 || fail "SIGKILL escalation test container did not become ready"
+    docker stop -t 5 "$cid" >/dev/null || fail "docker stop failed for SIGKILL escalation test container"
+
+    local exit_code
+    exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$cid" 2>/dev/null || true)
+    [[ "$exit_code" == "137" ]] || fail "expected container exit code 137 after SIGKILL escalation, got ${exit_code}"
+    pass "SIGKILL escalation works in the final image"
+}
+
+cd "$REPO_DIR"
+
+test_image_exists
+test_entrypoint_metadata
+test_runtime_files_and_user
+test_exit_code_propagation
+test_root_owned_hooks_execute
+test_sigterm_is_forwarded
+test_sigkill_after_timeout

--- a/zookeeper/tests/source-entrypoint-framework.sh
+++ b/zookeeper/tests/source-entrypoint-framework.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Lightweight source-level behavioral tests for the zookeeper-vendored entrypoint framework.
+#
+# These tests source the framework libraries directly from the working tree so
+# they can validate lifecycle logic without requiring a full container image
+# build. Use image-entrypoint-framework.sh after building the image to validate
+# final container wiring.
+#
+# Keep this aligned with the entrypoint itself: no `set -e`. The lifecycle
+# functions intentionally inspect non-zero wait statuses.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PRODUCT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+LIB_DIR="${PRODUCT_DIR}/kubedoop/lib"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+fail() {
+    echo "not ok - $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "ok - $*"
+}
+
+wait_for_file() {
+    local path="$1"
+    local timeout="${2:-5}"
+    local elapsed=0
+
+    while [[ ! -e "$path" && $elapsed -lt $timeout ]]; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    [[ -e "$path" ]]
+}
+
+# shellcheck source=/dev/null
+source "${LIB_DIR}/log.sh"
+# shellcheck source=/dev/null
+source "${LIB_DIR}/run-phase.sh"
+# shellcheck source=/dev/null
+source "${LIB_DIR}/signal.sh"
+
+KUBEDOOP_KILL_TIMEOUT=2
+KUBEDOOP_MOUNT_DIR="${TMP_DIR}/mount"
+mkdir -p "${KUBEDOOP_MOUNT_DIR}/pre-script" "${KUBEDOOP_MOUNT_DIR}/post-script"
+
+test_normal_exit_code() {
+    EXIT_CODE=0
+    run_lifecycle bash -c 'exit 7'
+    [[ "$EXIT_CODE" -eq 7 ]] || fail "expected normal exit code 7, got ${EXIT_CODE}"
+    pass "normal main-process exit code is preserved"
+}
+
+test_sigterm_is_forwarded() {
+    local child_ready="${TMP_DIR}/child-ready"
+    local child_term="${TMP_DIR}/child-term"
+
+    (
+        source "${LIB_DIR}/log.sh"
+        source "${LIB_DIR}/run-phase.sh"
+        source "${LIB_DIR}/signal.sh"
+        KUBEDOOP_KILL_TIMEOUT=2
+        KUBEDOOP_MOUNT_DIR="${TMP_DIR}/missing-hooks"
+        run_lifecycle bash -c '
+            trap "echo term > \"$1\"; exit 42" TERM
+            echo ready > "$2"
+            while :; do sleep 1; done
+        ' bash "$child_term" "$child_ready"
+        exit "$EXIT_CODE"
+    ) &
+    local lifecycle_pid=$!
+
+    wait_for_file "$child_ready" || fail "child did not report readiness"
+    kill -TERM "$lifecycle_pid"
+
+    local rc=0
+    wait "$lifecycle_pid" || rc=$?
+
+    [[ "$rc" -eq 42 ]] || fail "expected lifecycle exit code 42 after forwarded SIGTERM, got ${rc}"
+    grep -qx 'term' "$child_term" || fail "child did not receive forwarded SIGTERM"
+    pass "SIGTERM is forwarded and child exit code is preserved"
+}
+
+test_sigkill_after_timeout() {
+    local child_ready="${TMP_DIR}/ignore-ready"
+
+    (
+        source "${LIB_DIR}/log.sh"
+        source "${LIB_DIR}/run-phase.sh"
+        source "${LIB_DIR}/signal.sh"
+        KUBEDOOP_KILL_TIMEOUT=1
+        KUBEDOOP_MOUNT_DIR="${TMP_DIR}/missing-hooks"
+        run_lifecycle bash -c '
+            trap "" TERM
+            echo ready > "$1"
+            while :; do sleep 1; done
+        ' bash "$child_ready"
+        exit "$EXIT_CODE"
+    ) &
+    local lifecycle_pid=$!
+
+    wait_for_file "$child_ready" || fail "TERM-ignoring child did not report readiness"
+    kill -TERM "$lifecycle_pid"
+
+    local rc=0
+    wait "$lifecycle_pid" || rc=$?
+
+    [[ "$rc" -eq 137 ]] || fail "expected lifecycle exit code 137 after SIGKILL escalation, got ${rc}"
+    pass "SIGKILL escalation occurs after KUBEDOOP_KILL_TIMEOUT"
+}
+
+test_root_owned_phase_scripts_when_possible() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "skip - root-owned phase script execution requires running this test as root"
+        return 0
+    fi
+
+    local phase_dir="${TMP_DIR}/phase"
+    local marker="${TMP_DIR}/phase-order"
+    mkdir -p "$phase_dir"
+
+    cat > "${phase_dir}/20-second.sh" <<EOF
+#!/bin/bash
+echo second >> "${marker}"
+EOF
+    cat > "${phase_dir}/10-first.sh" <<EOF
+#!/bin/bash
+echo first >> "${marker}"
+EOF
+    chmod 0755 "${phase_dir}/10-first.sh" "${phase_dir}/20-second.sh"
+
+    run_phase "test-phase" "$phase_dir" || fail "root-owned phase scripts failed"
+
+    local order
+    order=$(tr '\n' ',' < "$marker")
+    [[ "$order" == "first,second," ]] || fail "expected sorted phase execution, got ${order}"
+    pass "root-owned executable phase scripts run in sorted order"
+}
+
+test_normal_exit_code
+test_sigterm_is_forwarded
+test_sigkill_after_timeout
+test_root_owned_phase_scripts_when_possible


### PR DESCRIPTION
## Summary

Implements the container process management framework from docs/container-process-management.md (#197) as a **product-first pilot in the zookeeper image**.

Closes #198.

## What's Included

- Add 	ini v0.19.0 as PID 1 for the ZooKeeper image.
- Add /kubedoop/bin/entrypoint.sh and vendored /kubedoop/lib/*.sh framework libraries for lifecycle management.
- Support root-owned executable runtime hooks under /kubedoop/mount/pre-script and /kubedoop/mount/post-script.
- Preserve main-process exit codes across normal and signal-driven shutdown paths.
- Improve SIGTERM timeout handling by reaping with a SIGALRM timer instead of polling kill -0, avoiding zombie children causing full-timeout delays.
- Fix ZooKeeper Log4Shell patch target to scan /kubedoop/zookeeper.
- Add source-level and image-level ZooKeeper entrypoint tests.
- Fix local yq download URL and ignore generated in/.

## Why Product-First

The design eventually places the framework in kubedoop-base, but changing that base image rebuilds every downstream image in the PR pipeline. This PR vendors the framework into ZooKeeper first so the behavior can be proven on one product before extraction into kubedoop-base.

## Tests

- make zookeeper-build
- ash -n zookeeper/tests/source-entrypoint-framework.sh zookeeper/tests/image-entrypoint-framework.sh
- zookeeper/tests/source-entrypoint-framework.sh
- zookeeper/tests/image-entrypoint-framework.sh

The image-level test validates the built image wiring: ENTRYPOINT, USER, file ownership/permissions, exit-code propagation, root-owned hooks, SIGTERM forwarding through tini and the entrypoint, and SIGKILL timeout escalation.

Note: buildx reported cache export warnings for registry cache targets, but the local image build completed successfully and loaded quay.io/zncdatadev/zookeeper:3.9.3-kubedoop0.0.0-dev.

## Deferred

- Extract framework into kubedoop-base after the product-first pilot is proven.
- Add pod-state coordination and sidecar watchdog pieces from the design.
- Migrate additional products.
