### PR TITLE
fix(build): correct yq/cosign install URLs and spark product name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ ifeq (,$(shell which yq 2>/dev/null))
 		mkdir -p $(dir $(YQ)) ;\
 		OS=$(shell uname -s | tr '[:upper:]' '[:lower:]') && \
 		ARCH=$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') && \
-		if [ "$${OS}" = "darwin" ]; then OS="macos"; fi && \
-		curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/latest/download/ya_$${OS}_$${ARCH} ;\
+		curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/latest/download/yq_$${OS}_$${ARCH} ;\
 		chmod +x $(YQ) ;\
 	}
 else
@@ -60,8 +59,7 @@ ifeq (,$(shell which cosign 2>/dev/null))
 		mkdir -p $(dir $(COSIGN)) ;\
 		OS=$(shell uname -s | tr '[:upper:]' '[:lower:]') && \
 		ARCH=$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/') && \
-		if [ "$${OS}" = "darwin" ]; then OS="macos"; fi && \
-		curl -sSLo $(COSIGN) https://github.com/sigstore/cosign/releases/latest/download/cosign-$$OS-$${ARCH} ;\
+		curl -sSLo $(COSIGN) https://github.com/sigstore/cosign/releases/latest/download/cosign-$${OS}-$${ARCH} ;\
 		chmod +x $(COSIGN) ;\
 	}
 else
@@ -199,11 +197,11 @@ kafka-buildx: jq ## Build Kafka image with buildx
 
 .PHONY:
 spark-build: jq ## Build Spark image
-	.scripts/build.sh spark
+	.scripts/build.sh spark-k8s
 
 .PHONY:
 spark-buildx: jq ## Build Spark image with buildx
-	.scripts/build.sh spark --push
+	.scripts/build.sh spark-k8s --push
 
 .PHONY:
 superset-build: jq ## Build Superset image


### PR DESCRIPTION
## Summary

Fixes two bugs in the `Makefile`:

- **yq auto-install**: the download URL had a typo in the asset name (`ya_` instead of `yq_`) and mapped Darwin to `macos`, but mikefarah/yq release assets are named `yq_darwin_*`. Both issues made `make yq` download a nonexistent asset on macOS (and the typo broke it on Linux too).
- **cosign auto-install**: same Darwin→`macos` mapping, but sigstore/cosign release assets use `darwin`. Only jq release assets actually use `macos`, so jq's mapping is left as is.
- **spark targets**: `spark-build`/`spark-buildx` passed `spark` to `.scripts/build.sh`, but the product directory and `project.yaml` entry are `spark-k8s`. With `spark`, `fill_products_version` found no `versions.yaml`, warned "Version file not found", and the empty product filter caused **all** bake targets to be built. The targets now pass `spark-k8s`.

## Verification

- Release asset names checked via HEAD requests: `yq_darwin_arm64`, `cosign-darwin-arm64`, `yq_linux_amd64`, `cosign-linux-amd64` → 200; the `macos`-named yq/cosign variants → 404; `jq-macos-arm64` → 200 (jq unchanged).
- `make -n spark-build` → `.scripts/build.sh spark-k8s`
- Dry-run of the install recipes with yq/cosign absent from PATH resolves to the correct `*_darwin_arm64` / `*-darwin-arm64` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)