### PR TITLE
feat(build): add helloworld make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,14 @@ vector-build: ## Build Vector image
 vector-buildx: jq ## Build Vector image with buildx
 	.scripts/build.sh vector --push
 
+.PHONY:
+helloworld-build: jq ## Build helloworld image
+	.scripts/build.sh helloworld
+
+.PHONY:
+helloworld-buildx: jq ## Build helloworld image with buildx
+	.scripts/build.sh helloworld --push
+
 ##@ develop environment
 
 .PHONY:


### PR DESCRIPTION
## Summary

Every product listed in `project.yaml` has a `<product>-build` / `<product>-buildx` target pair in the Makefile — except `helloworld`, which is a real product (own directory with Dockerfile/versions.yaml and its own CI workflow `build_helloworld.yaml`).

This adds `helloworld-build` and `helloworld-buildx` following the same pattern as the other products, under the `##@ infra` section (matching its grouping alongside `kubedoop-base` and `vector` in `project.yaml`).

## Verification

```
$ make -n helloworld-build
.scripts/build.sh helloworld
$ make -n helloworld-buildx
.scripts/build.sh helloworld --push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)